### PR TITLE
Set home directory as default save directory

### DIFF
--- a/mousepad/mousepad-window.c
+++ b/mousepad/mousepad-window.c
@@ -4006,6 +4006,8 @@ mousepad_window_action_save_as (GtkAction      *action,
   current_filename = mousepad_file_get_filename (document->file);
   if (current_filename)
     gtk_file_chooser_set_filename (GTK_FILE_CHOOSER (dialog), current_filename);
+  else
+    gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER (dialog), g_get_home_dir());
 
   /* run the dialog */
   if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_OK)


### PR DESCRIPTION
When you save a file for the first time, the recently used files are shown by default (at least on my machine). This doesn't really make sense because you can't save there. Showing the home dir in this case might be a slightly better UX.